### PR TITLE
Add customQuery option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Autocompleter has the following options:
 | ignoredKeyCode | array |  Array with ignorable keycodes, by default: ``9, 13, 17, 19, 20, 27, 33, 34, 35, 36, 37, 39, 44, 92, 113, 114, 115, 118, 119, 120, 122, 123, 144, 145`` | [] |
 | customLabel  | str | The name of object's property which will be used as a label | false |
 | customValue  | str | The name of object's property which will be used as a value | false |
+| customQuery  | str | The name of query's name which will be used as a parameter | false |
 | template | str | Custom template for list items. For example: ``<span>{{ label }} is {{ customPropertyFromSource }}</span>``. Template appends to ``.autocompleter-item``. | false |
 | offset | str | Source response offset, for example: response.items.posts | false |
 | combine | function | Returns an object which extends ajax data. Useful if you want to pass some additional server options | $.noop |

--- a/jquery.autocompleter.js
+++ b/jquery.autocompleter.js
@@ -24,6 +24,7 @@
             'ignoredKeyCode',
             'customLabel',
             'customValue',
+            'customQuery',
             'template',
             'offset',
             'combine',
@@ -74,6 +75,7 @@
      * @param ignoredKeyCode [array] <[]> "Array with ignorable keycodes"
      * @param customLabel [boolean] <false> "The name of object's property which will be used as a label"
      * @param customValue [boolean] <false> "The name of object's property which will be used as a value"
+     * @param customQuery [boolean] <false> "The name of query's name which will be used as a parameter"
      * @param template [(string|boolean)] <false> "Custom template for list items"
      * @param offset [(string|boolean)] <false> "Source response offset, for example: response.items.posts"
      * @param combine [function] <$.noop> "Returns an object which extends ajax data. Useful if you want to pass some additional server options"
@@ -97,6 +99,7 @@
         ignoredKeyCode: [],
         customLabel: false,
         customValue: false,
+        customQuery: false,
         template: false,
         offset: false,
         combine: $.noop,
@@ -392,14 +395,21 @@
                 _response(search, data);
             }
         } else {
+            var extend = {
+                limit: data.limit
+            };
+
             if (data.jqxhr) {
                 data.jqxhr.abort();
             }
 
-            var ajaxData = $.extend({
-                limit: data.limit,
-                query: data.query
-            }, data.combine(data.query));
+            if(data.customQuery){
+                extend[data.customQuery] = data.query;
+            }else{
+                extend.query = data.query;
+            }
+
+            var ajaxData = $.extend(extend, data.combine(data.query));
 
             data.jqxhr = $.ajax({
                 url:        data.source,


### PR DESCRIPTION
In some cases, the source url has another parameter name like `q` instead of `query`, so this commit adds `customQuery` to replace that name.
